### PR TITLE
Add support for SSD disks

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -57,10 +57,29 @@ func (vb *VBox) AddStorageController(vm *VirtualMachine, ctr StorageController) 
 }
 
 func (vb *VBox) AttachStorage(vm *VirtualMachine, disk *Disk) error {
-
-	_, err := vb.manage("storageattach", vm.Spec.Name, "--storagectl", disk.Controller.Name,
-		"--port", strconv.Itoa(disk.Controller.Port), "--device", strconv.Itoa(disk.Controller.Device),
-		"--type", string(disk.Type), "--medium", disk.Path)
+	nonRotational := "off"
+	if disk.NonRotational {
+		nonRotational = "on"
+	}
+	autoDiscard := "off"
+	if disk.AutoDiscard {
+		if disk.Format != VDI {
+			glog.Warning(
+				"Disk format ", disk.Format, " is not VDI. ",
+				"Ignoring AutoDiscard.")
+		} else {
+			autoDiscard = "on"
+		}
+	}
+	_, err := vb.manage(
+		"storageattach", vm.Spec.Name,
+		"--storagectl", disk.Controller.Name,
+		"--port", strconv.Itoa(disk.Controller.Port),
+		"--device", strconv.Itoa(disk.Controller.Device),
+		"--type", string(disk.Type),
+		"--medium", disk.Path,
+		"--nonrotational", nonRotational,
+		"--discard", autoDiscard)
 
 	return err
 }

--- a/types.go
+++ b/types.go
@@ -31,12 +31,14 @@ func (d DiskType) ForShowMedium() string {
 
 type Disk struct {
 	// Path represents the absolute path in the system where the disk is stored, normally is under the vm folder
-	Path       string
-	SizeMB     int64
-	Format     DiskFormat
-	UUID       string
-	Controller StorageControllerAttachment
-	Type       DiskType
+	Path          string
+	SizeMB        int64
+	Format        DiskFormat
+	UUID          string
+	Controller    StorageControllerAttachment
+	Type          DiskType
+	NonRotational bool
+	AutoDiscard   bool
 }
 
 type StorageControllerAttachment struct {


### PR DESCRIPTION
Add 'NonRotational' and 'AutoDiscard' Disk options
that map to vboxmanage's '--nonrotational' and
'--discard' options.

See: https://www.virtualbox.org/manual/ch08.html

Enable AutoDiscard only if disk format is VDI.