### PR TITLE
fix typo in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,7 +80,7 @@ func CreateVM() {
 
 ### Get VM Info
 ```go
-func GetVMInfo(name string) (machine *vbm.VirtualMachine, err error) {
+func GetVMInfo(name string) (machine *vbg.VirtualMachine, err error) {
     vb := vbg.NewVBox(vbg.Config{})
     return vb.VMInfo(name)
 }


### PR DESCRIPTION
It should be the vbg of the imported module name.